### PR TITLE
Add custom attributes to day elements in DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ const my_calendar = new TavoCalendar('.calendar', options);
 * `future_select` (*optional*) -- disable selecting days after `date` (defaults to `true`)
 * `past_select` (*optional*) -- disable selecting days before `date` (defaults to `false`)
 * `frozen` (*optional*) -- disable all interactions (defaults to `false`)
-* `highligh_sunday` (*optional*) -- highlight sundays (defaults to `true`)
+* `highlight_sunday` (*optional*) -- highlight sundays (defaults to `true`)
+* `custom_attributes` (*optional*) -- `Object` that adds custom attributes `data-Object.property` to your day elements in DOM. See `examples/custom.html` for examples  (defaults to `null`)
 
 **Available methods**
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -17,13 +17,17 @@
     <body>
         <div id="my-calendar"></div>
             
-        <script src="../node_modules/moment/moment.js" ></script>
-        <script src="../dist/tavo-calendar.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
+        <script src="../src/TavoCalendar.js"></script>
 
         <script>
             const my_calendar = new TavoCalendar('#my-calendar', {
                 date: "2014-12-21",
-                selected: ["2014-12-24"]
+                selected: ["2014-12-24"],
+                custom_properties: {
+                    'href': '/parties/create',
+                    'click': 'false' 
+                }
             })
         </script>   
     </body>

--- a/examples/custom.html
+++ b/examples/custom.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>TavoCalendar basic</title>
+        <title>TavoCalendar custom attributes</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="../dist/tavo-calendar.css">
         <style>
@@ -17,14 +17,24 @@
     <body>
         <div id="my-calendar"></div>
             
-        <script src="../node_modules/moment/moment.js" ></script>
-        <script src="../dist/tavo-calendar.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
+        <script src="../src/TavoCalendar.js"></script>
 
         <script>
             const my_calendar = new TavoCalendar('#my-calendar', {
                 date: "2014-12-21",
-                selected: ["2014-12-24"]
+                selected: ["2014-12-24"],
+                custom_attributes: {
+                    'href': '/link/',
+                    'foo': 'bar' 
+                }
             })
+
+            /*
+                Your day element in DOM becomes:
+                <span class="tavo-calendar__day-inner" data-href="/link/" data-foo="bar">24</span>
+                Notice the data-* attributes
+            */
         </script>   
     </body>
 </html>

--- a/src/TavoCalendar.js
+++ b/src/TavoCalendar.js
@@ -92,7 +92,8 @@
         past_select: false,
         frozen: false,
         highlight_sunday: true,
-        highlight_saturday: false
+        highlight_saturday: false,
+        custom_properties: null
     }
 
     var TavoCalendar = function(container_q, user_options) {
@@ -127,6 +128,7 @@
             selected: config.selected ? config.selected : [],
             highlight: config.highlight ? config.highlight : [],
             blacklist: config.blacklist ? config.blacklist : [],
+            custom_properties: config.custom_properties ? config.custom_properties : {},
             date_start: config.date_start,
             date_end: config.date_end,
             lock: config.lock || config.frozen 
@@ -264,6 +266,16 @@
 
             day_el = document.createElement("span");
             day_el.className = CLASS_CALENDAR_INNER;
+            
+            // Add custom attributes to days in DOM
+            if(this.config.custom_properties){
+                const attributes = Object.entries(this.config.custom_properties);
+                for(const attribute of attributes){
+                    const key = attribute[0];
+                    const value = attribute[1];
+                    day_el.setAttribute("data-" + key, value);
+                }
+            }
 
             const that = this;
             const date = moment_copy.format(that.config.format);

--- a/src/TavoCalendar.js
+++ b/src/TavoCalendar.js
@@ -93,7 +93,7 @@
         frozen: false,
         highlight_sunday: true,
         highlight_saturday: false,
-        custom_properties: null
+        custom_attributes: null
     }
 
     var TavoCalendar = function(container_q, user_options) {
@@ -128,7 +128,7 @@
             selected: config.selected ? config.selected : [],
             highlight: config.highlight ? config.highlight : [],
             blacklist: config.blacklist ? config.blacklist : [],
-            custom_properties: config.custom_properties ? config.custom_properties : {},
+            custom_attributes: config.custom_attributes ? config.custom_attributes : {},
             date_start: config.date_start,
             date_end: config.date_end,
             lock: config.lock || config.frozen 
@@ -268,8 +268,8 @@
             day_el.className = CLASS_CALENDAR_INNER;
             
             // Add custom attributes to days in DOM
-            if(this.config.custom_properties){
-                const attributes = Object.entries(this.config.custom_properties);
+            if(this.config.custom_attributes){
+                const attributes = Object.entries(this.config.custom_attributes);
                 for(const attribute of attributes){
                     const key = attribute[0];
                     const value = attribute[1];


### PR DESCRIPTION
Hi!

I needed to add custom attributes to the HTML `day_el` so I made a new config option.
This `custom_attributes` object will translate in `data-*=` (with the attribute and the value) in the DOM.

Please note that I've only very rapidly developed it and only tested it for my use case and a few others I could think of. You might need to extensively check the code and test it.

Also note that I've used the `TavoCalendar.js` script in the `src` folder, which is currently in v0.0.4 (the `dist/tavo-calendar` is in 0.0.3). 

Have a nice weekend